### PR TITLE
Return created task message

### DIFF
--- a/docs/api-reference/agent/tasks.mdx
+++ b/docs/api-reference/agent/tasks.mdx
@@ -12,11 +12,25 @@ The Tasks API allows you to manage tasks in the Bytebot agent system. It's avail
 ```typescript
 {
   id: string;
-  description: string; 
+  description: string;
   status: 'PENDING' | 'IN_PROGRESS' | 'NEEDS_HELP' | 'NEEDS_REVIEW' | 'COMPLETED' | 'CANCELLED' | 'FAILED';
   priority: 'LOW' | 'MEDIUM' | 'HIGH' | 'URGENT';
-  createdAt: string; 
-  updatedAt: string; 
+  createdAt: string;
+  updatedAt: string;
+}
+```
+
+## Message Model
+
+```typescript
+{
+  id: string;
+  content: MessageContentBlock[];
+  role: 'USER' | 'ASSISTANT';
+  taskId: string;
+  createdAt: string;
+  updatedAt: string;
+  summaryId?: string | null;
 }
 ```
 
@@ -147,6 +161,38 @@ Retrieve a specific task by its ID.
     }
     // ...more messages
   ]
+  }
+  ```
+
+### Add Task Message
+
+Add a user message to an existing task.
+
+<Card title="POST /tasks/:id/messages" icon="chat-bubble-left">
+  Add a message to a task
+</Card>
+
+#### Request Body
+
+```json
+{
+  "message": "Additional instructions for the task"
+}
+```
+
+#### Response
+
+```json
+{
+  "id": "msg-456",
+  "content": [
+    { "type": "text", "text": "Additional instructions for the task" }
+  ],
+  "role": "USER",
+  "taskId": "task-123",
+  "createdAt": "2025-04-14T12:05:00Z",
+  "updatedAt": "2025-04-14T12:05:00Z",
+  "summaryId": null
 }
 ```
 

--- a/docs/core-concepts/agent-system.mdx
+++ b/docs/core-concepts/agent-system.mdx
@@ -178,8 +178,8 @@ GET /tasks/:id
 // Send a message
 POST /tasks/:id/messages
 {
-  "content": "Additional instructions"
-}
+  "message": "Additional instructions"
+} // returns created message
 
 // Get task history
 GET /tasks/:id/messages

--- a/packages/bytebot-agent/src/tasks/dto/task-message.dto.ts
+++ b/packages/bytebot-agent/src/tasks/dto/task-message.dto.ts
@@ -1,0 +1,12 @@
+import { Role } from '@prisma/client';
+import { MessageContentBlock } from '@bytebot/shared';
+
+export interface TaskMessageDto {
+  id: string;
+  content: MessageContentBlock[];
+  role: Role;
+  taskId: string;
+  createdAt: Date;
+  updatedAt: Date;
+  summaryId?: string | null;
+}

--- a/packages/bytebot-agent/src/tasks/tasks.controller.ts
+++ b/packages/bytebot-agent/src/tasks/tasks.controller.ts
@@ -16,6 +16,7 @@ import { TasksService } from './tasks.service';
 import { CreateTaskDto } from './dto/create-task.dto';
 import { Message, Task } from '@prisma/client';
 import { AddTaskMessageDto } from './dto/add-task-message.dto';
+import { TaskMessageDto } from './dto/task-message.dto';
 import { MessagesService } from '../messages/messages.service';
 import { ANTHROPIC_MODELS } from '../anthropic/anthropic.constants';
 import { OPENAI_MODELS } from '../openai/openai.constants';
@@ -156,7 +157,7 @@ export class TasksController {
     @Param('id') taskId: string,
     @Body() guideTaskDto: AddTaskMessageDto,
     @Req() req: RequestWithUser,
-  ): Promise<Task> {
+  ): Promise<TaskMessageDto> {
     return this.tasksService.addTaskMessage(taskId, guideTaskDto, req.user!.id);
   }
 

--- a/packages/bytebot-agent/src/tasks/tasks.service.ts
+++ b/packages/bytebot-agent/src/tasks/tasks.service.ts
@@ -19,6 +19,8 @@ import {
   File,
 } from '@prisma/client';
 import { AddTaskMessageDto } from './dto/add-task-message.dto';
+import { TaskMessageDto } from './dto/task-message.dto';
+import { MessageContentBlock } from '@bytebot/shared';
 import { TasksGateway } from './tasks.gateway';
 import { ConfigService } from '@nestjs/config';
 import { EventEmitter2 } from '@nestjs/event-emitter';
@@ -265,7 +267,7 @@ export class TasksService {
           this.tasksGateway.emitTaskUpdate(id, updatedTask);
         }
       } catch (e) {
-        this.logger.error('Failed to take over task in update', e as any);
+        this.logger.error('Failed to take over task in update', e);
       }
     } else if (updateTaskDto.status === TaskStatus.FAILED) {
       this.eventEmitter.emit('task.failed', { taskId: id });
@@ -300,7 +302,7 @@ export class TasksService {
     taskId: string,
     addTaskMessageDto: AddTaskMessageDto,
     userId: string,
-  ) {
+  ): Promise<TaskMessageDto> {
     const task = await this.findByIdForUser(taskId, userId);
     if (!task) {
       this.logger.warn(`Task with ID: ${taskId} not found for guiding`);
@@ -316,7 +318,10 @@ export class TasksService {
     });
 
     this.tasksGateway.emitNewMessage(taskId, message);
-    return task;
+    return {
+      ...message,
+      content: message.content as MessageContentBlock[],
+    };
   }
 
   async resume(taskId: string, userId: string): Promise<Task> {


### PR DESCRIPTION
## Summary
- Return the created message from `addTaskMessage` instead of the task
- Introduce `TaskMessageDto` and update controller endpoint typings
- Document task message model and messaging endpoint

## Testing
- `npm run lint` *(fails: numerous existing lint errors)*
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68c45227c2c4832f86707c7fd6f10932